### PR TITLE
Bump mimemagic version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mimemagic (0.3.3)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -246,4 +248,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/README.md
+++ b/README.md
@@ -1,24 +1,9 @@
-# README
+# Employee Directory
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+This is a sample application demonstrating [Graphiti](https://github.com/graphiti-api/graphiti).
 
-Things you may want to cover:
+## Setup
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+ - Run `bin/setup`.
+ - `rails server`
+ - Visit `/api/v1/vandal`.


### PR DESCRIPTION
The older version of mimemagic was yanked, so this patch bumps to a
newer version.

Also tweaks the README to include setup instructions.